### PR TITLE
Update mbed-os to mbed-os-5.2.2

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#e2617cc0e17f5c3fc2bae6a589c9bcfd3d1a717b
+https://github.com/ARMmbed/mbed-os/#a1c0840b3d69060e5eb708edb18358e424a40f51


### PR DESCRIPTION
This PR is to update mbed-os library to mbed-os-5.2.2. Before accepting please run suitable tests to ensure that this update is compatible with this example. Decline the PR if you do not wish to accept.