### PR TITLE
Add NUCLEO_F429ZI + NUCLEO_L476RG support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The program brings up the WiFi and the underlying network interface, and uses it
 
 ### Supported hardware ###
 
-* [UBLOX Odin board](https://developer.mbed.org/platforms/ublox-EVK-ODIN-W2/) (`UBLOX_EVK_ODIN_W2` target when using mbed CLI)
-* [NUCLEO_F429ZI](https://developer.mbed.org/platforms/ST-Nucleo-F429ZI/) with ESP8266-01 module
-* [NUCLEO_L476RG](https://developer.mbed.org/platforms/ST-Nucleo-L476RG/) with ESP8266-01 module
+* [UBLOX Odin board](https://developer.mbed.org/platforms/ublox-EVK-ODIN-W2/) (`UBLOX_EVK_ODIN_W2` target when using mbed CLI) with ESP8266-01 module using pins D1 D0
+* [NUCLEO_F429ZI](https://developer.mbed.org/platforms/ST-Nucleo-F429ZI/) with ESP8266-01 module using pins D1 D0
+* [NUCLEO_L476RG](https://developer.mbed.org/platforms/ST-Nucleo-L476RG/) with ESP8266-01 module using pins D8 D2
 * Other mbed target with ESP2866 module (Board it's connected to shouldn't have other network interface eg. Ethernet)
 
 ESP2866 is a fallback option and will be used if the build is for unsupported platform.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The program brings up the WiFi and the underlying network interface, and uses it
 ### Supported hardware ###
 
 * [UBLOX Odin board](https://developer.mbed.org/platforms/ublox-EVK-ODIN-W2/) (`UBLOX_EVK_ODIN_W2` target when using mbed CLI)
+* [NUCLEO_F429ZI](https://developer.mbed.org/platforms/ST-Nucleo-F429ZI/) with ESP8266-01 module
+* [NUCLEO_L476RG](https://developer.mbed.org/platforms/ST-Nucleo-L476RG/) with ESP8266-01 module
 * Other mbed target with ESP2866 module (Board it's connected to shouldn't have other network interface eg. Ethernet)
 
 ESP2866 is a fallback option and will be used if the build is for unsupported platform.

--- a/main.cpp
+++ b/main.cpp
@@ -21,22 +21,13 @@
 #include "OdinWiFiInterface.h"
 OdinWiFiInterface wifi;
 
-#elif TARGET_NUCLEO_L476RG
-#include "ESP8266Interface.h"
-// ESP8266_WIFI TX to be connected to D2 (Serial1_Rx)
-// ESP8266_WIFI_RX to be connected to D8 (Serial1_Tx)
-ESP8266Interface wifi(D8, D2);
-
-#elif  TARGET_NUCLEO_F429ZI
-#include "ESP8266Interface.h"
-ESP8266Interface wifi(D1, D0);
 #else
 #if !TARGET_FF_ARDUINO
 #error [NOT_SUPPORTED] Only Arduino form factor devices are supported at this time
 #endif
 #include "ESP8266Interface.h"
 
-ESP8266Interface wifi(D1, D0);
+ESP8266Interface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
 
 #endif
 

--- a/main.cpp
+++ b/main.cpp
@@ -20,12 +20,24 @@
 #if TARGET_UBLOX_EVK_ODIN_W2
 #include "OdinWiFiInterface.h"
 OdinWiFiInterface wifi;
+
+#elif TARGET_NUCLEO_L476RG
+#include "ESP8266Interface.h"
+// ESP8266_WIFI TX to be connected to D2 (Serial1_Rx)
+// ESP8266_WIFI_RX to be connected to D8 (Serial1_Tx)
+ESP8266Interface wifi(D8, D2);
+
+#elif  TARGET_NUCLEO_F429ZI
+#include "ESP8266Interface.h"
+ESP8266Interface wifi(D1, D0);
 #else
 #if !TARGET_FF_ARDUINO
 #error [NOT_SUPPORTED] Only Arduino form factor devices are supported at this time
 #endif
 #include "ESP8266Interface.h"
+
 ESP8266Interface wifi(D1, D0);
+
 #endif
 
 const char *sec2str(nsapi_security_t sec)

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -6,12 +6,24 @@
         },
         "wifi-password": {
             "help": "WiFi Password",
-            "value": "\"Password\""
+            "value": "\"PASSWORD\""
+        },
+        "wifi-tx": {
+            "help": "TX pin for serial connection to external device",
+            "value": "D1"
+        },
+        "wifi-rx": {
+            "help": "RX pin for serial connection to external device",
+            "value": "D0"
         }
     },
     "target_overrides": {
         "UBLOX_EVK_ODIN_W2": {
             "target.device_has": ["EMAC"]
+        },
+        "NUCLEO_L476RG": {
+            "wifi-tx": "D8",
+            "wifi-rx": "D2"
         }
     }
 }


### PR DESCRIPTION
Hello,
I've been able to use this test with NUCLEO_F429ZI and NUCLEO_L476RG, together with an ESP8266-01 wifi module
```
Connecting...
Success

MAC: 18:fe:34:13:c1:9e
IP: 192.168.1.100
Netmask: (null)
Gateway: (null)
RSSI: 0

Sending HTTP request to www.arm.com...
sent 38 [GET / HTTP/1.1]
recv 64 [HTTP/1.1 200 OK]

Done
```

Is it possible to add this modification to main.cpp + Readme file, please ?
@bcostm