### PR TITLE
Remove irrelevant lib

### DIFF
--- a/esp8266-driver.lib
+++ b/esp8266-driver.lib
@@ -1,1 +1,0 @@
-https://github.com/armmbed/esp8266-driver/#dc37b65ca877d969aa492f348626df6e1b0b1df0


### PR DESCRIPTION
esp8266-driver.lib is irrelevant to ameba target, consider removing this lib so users won't be confused. 