### PR TITLE
Add ISM43362 driver support for STM32 wifi DISCO boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ For more information about Wi-Fi APIs, please visit the [Mbed OS Wi-Fi](https://
 
 * [u-blox Odin board](https://os.mbed.com/platforms/ublox-EVK-ODIN-W2/) built-in Wi-Fi module.
 * [Realtek RTL8195AM](https://os.mbed.com/platforms/REALTEK-RTL8195AM/) built-in Wi-Fi module.
+* [ST DISCO IOT board](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/) with integrated [ISM43362 WiFi Inventek module](https://github.com/ARMmbed/wifi-ism43362).
+* [ST DISCO_F413ZH board](https://os.mbed.com/platforms/ST-Discovery-F413H/) with integrated [ISM43362 WiFi Inventek module](https://github.com/ARMmbed/wifi-ism43362).
 * [NUCLEO-F401RE](https://os.mbed.com/platforms/ST-Nucleo-F401RE/) with [X-NUCLEO-IDW04A1](http://www.st.com/content/st_com/en/products/ecosystems/stm32-open-development-environment/stm32-nucleo-expansion-boards/stm32-ode-connect-hw/x-nucleo-idw04a1.html) Wi-Fi expansion board using pins D8 and D2 _(of the Arduino connector)_.
 * [NUCLEO-F401RE](https://os.mbed.com/platforms/ST-Nucleo-F401RE/) with [X-NUCLEO-IDW01M1](https://os.mbed.com/components/X-NUCLEO-IDW01M1/) Wi-Fi expansion board using pins PA_9 and PA_10 _(of the Morpho connector)_.
 * [NUCLEO-F429ZI](https://os.mbed.com/platforms/ST-Nucleo-F429ZI/) with ESP8266-01 module using pins D1 and D0.
@@ -49,7 +51,7 @@ To connect the [X-NUCLEO-IDW04A1](http://www.st.com/content/st_com/en/products/e
    ```
        "config": {
  	  "wifi-shield": {
-               "help": "Options are WIFI_ESP8266, WIFI_IDW0XX1",
+               "help": "Options are internal, WIFI_ESP8266, WIFI_ISM43362, WIFI_IDW0XX1",
                "value": "WIFI_ESP8266"
         	  },
            "wifi-ssid": {
@@ -65,6 +67,8 @@ To connect the [X-NUCLEO-IDW04A1](http://www.st.com/content/st_com/en/products/e
 
    Sample ```mbed_app.json``` files are provided for ESP8266 (```mbed_app_esp8266.json```), X-NUCLEO-IDW04A1 (```mbed_app_idw04a1.json```) and X-NUCLEO-IDW01M1 (```mbed_app_idw01m1```).
    
+   For WIFI_ISM43362, ignore the value of `wifi-shield` as it is already overrides per supported targets.
+
    For built-in Wi-Fi, ignore the value of `wifi-shield`.
 
 3. Compile and generate binary.

--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,7 @@
 
 #define WIFI_ESP8266    1
 #define WIFI_IDW0XX1    2
+#define WIFI_ISM43362   3
 
 #if TARGET_UBLOX_EVK_ODIN_W2
 #include "OdinWiFiInterface.h"
@@ -33,9 +34,15 @@ RTWInterface wifi;
 #if MBED_CONF_APP_WIFI_SHIELD == WIFI_ESP8266
 #include "ESP8266Interface.h"
 ESP8266Interface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
+
+#elif MBED_CONF_APP_WIFI_SHIELD == WIFI_ISM43362
+#include "ISM43362Interface.h"
+ISM43362Interface wifi;
+
 #elif MBED_CONF_APP_WIFI_SHIELD == WIFI_IDW0XX1
 #include "SpwfSAInterface.h"
 SpwfSAInterface wifi(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
+
 #endif // MBED_CONF_APP_WIFI_SHIELD == WIFI_IDW0XX1
 
 #endif

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,9 +1,9 @@
 {
     "config": {
-	"wifi-shield": {
-            "help": "Options are internal, WIFI_ESP8266, WIFI_IDW0XX1",
+        "wifi-shield": {
+            "help": "Options are internal, WIFI_ESP8266, WIFI_ISM43362, WIFI_IDW0XX1",
             "value": "internal"
-	},
+        },
         "wifi-ssid": {
             "help": "WiFi SSID",
             "value": "\"SSID\""
@@ -27,6 +27,26 @@
         },
         "UBLOX_EVK_ODIN_W2": {
             "target.device_has": ["EMAC"]
+        },
+        "DISCO_F413ZH": {
+            "wifi-shield": "WIFI_ISM43362",
+            "ism43362.wifi-miso": "PB_4",
+            "ism43362.wifi-mosi": "PB_5",
+            "ism43362.wifi-sclk": "PB_12",
+            "ism43362.wifi-nss": "PG_11",
+            "ism43362.wifi-reset": "PH_1",
+            "ism43362.wifi-dataready": "PG_12",
+            "ism43362.wifi-wakeup": "PB_15"
+        },
+        "DISCO_L475VG_IOT01A": {
+            "wifi-shield": "WIFI_ISM43362",
+            "ism43362.wifi-miso": "PC_11",
+            "ism43362.wifi-mosi": "PC_12",
+            "ism43362.wifi-sclk": "PC_10",
+            "ism43362.wifi-nss": "PE_0",
+            "ism43362.wifi-reset": "PE_8",
+            "ism43362.wifi-dataready": "PE_1",
+            "ism43362.wifi-wakeup": "PB_13"
         },
         "NUCLEO_L476RG": {
             "wifi-tx": "D8",

--- a/wifi-ism43362.lib
+++ b/wifi-ism43362.lib
@@ -1,0 +1,1 @@
+https://github.com/armmbed/wifi-ism43362/#898ec07a06530bc65ba7525c048ba1fcb5e3b0c8


### PR DESCRIPTION
We would like to introduce ISM 43362 Wifi drivers in this mbed os example.

https://github.com/ARMmbed/wifi-ism43362

This WiFi Inventek module is currenlty available with 2 ST DISCO boards:
- DISCO_L475VG_IOT01A : https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/
- DISCO_F413ZH : https://os.mbed.com/platforms/ST-Discovery-F413H/

Example has been verified with both supported DISCO boards.

@adustm @bcostm @lmestm 
