### PR TITLE
Updated config files and fixed README.md minor displaying issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,9 @@ To connect the [X-NUCLEO-IDW04A1](http://www.st.com/content/st_com/en/products/e
    ```
 
 1. Configure the Wi-Fi shield and settings.
-
    Edit ```mbed_app.json``` to include the correct Wi-Fi shield, SSID and password:
 
-   ```
+```json
 {
     "config": {
         "wifi-ssid": {
@@ -81,8 +80,7 @@ To connect the [X-NUCLEO-IDW04A1](http://www.st.com/content/st_com/en/products/e
         }
     }
 }
-
-   ```
+```
 
    For build-in WiFi, you do not need to set any `provide-default` values. Those are required
    if you use external WiFi shield.

--- a/mbed_app_esp8266.json
+++ b/mbed_app_esp8266.json
@@ -7,14 +7,6 @@
         "wifi-password": {
             "help": "WiFi Password",
             "value": "\"PASSWORD\""
-        },
-        "wifi-tx": {
-            "help": "TX pin for serial connection to external device",
-            "value": "D1"
-        },
-        "wifi-rx": {
-            "help": "RX pin for serial connection to external device",
-            "value": "D0"
         }
     },
     "target_overrides": {

--- a/mbed_app_idw01m1.json
+++ b/mbed_app_idw01m1.json
@@ -7,14 +7,6 @@
         "wifi-password": {
             "help": "WiFi Password",
             "value": "\"PASSWORD\""
-        },
-        "wifi-tx": {
-            "help": "TX pin for serial connection to external device",
-            "value": "PA_9"
-        },
-        "wifi-rx": {
-            "help": "RX pin for serial connection to external device",
-            "value": "PA_10"
         }
     },
     "target_overrides": {
@@ -22,6 +14,8 @@
             "platform.stdio-convert-newlines": true,
             "idw0xx1.expansion-board": "IDW01M1",
             "idw0xx1.provide-default": true,
+            "idw0xx1.tx": "PA_9",
+            "idw0xx1.rx": "PA_10",
             "drivers.uart-serial-txbuf-size": 730,
             "drivers.uart-serial-rxbuf-size": 730
         },

--- a/mbed_app_idw04a1.json
+++ b/mbed_app_idw04a1.json
@@ -11,20 +11,15 @@
         "wifi-password": {
             "help": "WiFi Password",
             "value": "\"PASSWORD\""
-        },
-        "wifi-tx": {
-            "help": "TX pin for serial connection to external device",
-            "value": "D8"
-        },
-        "wifi-rx": {
-            "help": "RX pin for serial connection to external device",
-            "value": "D2"
         }
     },
     "target_overrides": {
         "*": {
             "platform.stdio-convert-newlines": true,
             "idw0xx1.expansion-board": "IDW04A1",
+            "idw0xx1.provide-default": true, 
+            "idw0xx1.tx": "PA_9",
+            "idw0xx1.rx": "PA_10",
 	    "drivers.uart-serial-txbuf-size": 750,
 	    "drivers.uart-serial-rxbuf-size": 750
         },


### PR DESCRIPTION
For ESP8266 the config worked out of the box and it worked just as well without the pins set, so I thought it is better to count on the defaults and I simplified the config.
idw01m1 did not work at first but it did after I updated the UART pins setting. I tested with NUCLEO_L476RG.
I do not have idw04a1 expansion board, so I could not really test it, I assumed the config changes should be same as for idw01m1.

The README.md file did not display the json config clearly and the enumeration seemed wrong (all points were "1."), so I fixed that as well.