### PR TITLE
Remove ESP8266 support for Nucleo boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ For more information about Wi-Fi APIs, please visit the [Mbed OS Wi-Fi](https://
     * [NUCLEO-F401RE](https://os.mbed.com/platforms/ST-Nucleo-F401RE/) with [X-NUCLEO-IDW04A1](http://www.st.com/content/st_com/en/products/ecosystems/stm32-open-development-environment/stm32-nucleo-expansion-boards/stm32-ode-connect-hw/x-nucleo-idw04a1.html) Wi-Fi expansion board using pins D8 and D2 _(of the Arduino connector)_.
     * [NUCLEO-F401RE](https://os.mbed.com/platforms/ST-Nucleo-F401RE/) with [X-NUCLEO-IDW01M1](https://os.mbed.com/components/X-NUCLEO-IDW01M1/) Wi-Fi expansion board using pins PA_9 and PA_10 _(of the Morpho connector)_.
     * [NUCLEO-F429ZI](https://os.mbed.com/platforms/ST-Nucleo-F429ZI/) with ESP8266-01 module using pins D1 and D0.
-    * [NUCLEO-L476RG](https://os.mbed.com/platforms/ST-Nucleo-L476RG/) with ESP8266-01 module using pins D8 and D2.
     * Other Mbed targets with an ESP8266 module, [X-NUCLEO-IDW04A1](http://www.st.com/content/st_com/en/products/ecosystems/stm32-open-development-environment/stm32-nucleo-expansion-boards/stm32-ode-connect-hw/x-nucleo-idw04a1.html) or [X-NUCLEO-IDW01M1](https://os.mbed.com/components/X-NUCLEO-IDW01M1/) expansion board.
 
 #### Adding connectivity driver
@@ -42,8 +41,6 @@ Then pin names need to be configured as instructed in the drivers README file.
 #### Connecting the ESP8266 ####
 
 To connect the ESP8266 module to your development board, look at the [ESP8266 Cookbook page](https://developer.mbed.org/users/4180_1/notebook/using-the-esp8266-with-the-mbed-lpc1768/). In general, this means hooking up the ESP8266 TX pin to `D0` and the ESP8266 RX pin to `D1` on your development board.
-
-**Note:** On NUCLEO development boards, pins `D0` and `D1` are used for serial communication with the computer. Use pins `D8` (to ESP8266 TX) and `D2` (to ESP8266 RX) instead.
 
 #### Connecting the X-NUCLEO-IDW0XX1 ####
 

--- a/mbed_app_esp8266.json
+++ b/mbed_app_esp8266.json
@@ -16,14 +16,6 @@
         },
         "UBLOX_EVK_ODIN_W2": {
             "target.device_has": ["EMAC"]
-        },
-        "NUCLEO_L476RG": {
-            "wifi-tx": "D8",
-            "wifi-rx": "D2"
-        },
-        "NUCLEO_F401RE": {
-            "wifi-tx": "D8",
-            "wifi-rx": "D2"
         }
     }
 }


### PR DESCRIPTION
ST Nucleo boards do not have the right pinout to work with ESP8266 via the Arduino-enabled shields.