### PR TITLE
Cleanup and simplify the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Wi-Fi example for Mbed OS
 
 ## Getting started with the Wi-Fi API ##
 
-This is an example of a Wi-Fi application using the Wi-Fi and network socket APIs that [Mbed OS](https://github.com/ARMmbed/mbed-os) provides.
+This is an example of a Wi-Fi application using the Wi-Fi APIs that [Mbed OS](https://github.com/ARMmbed/mbed-os) provides.
 
-The program brings up the Wi-Fi and the underlying network interface and uses it to scan available networks, connects to a network, prints interface and connection details and performs an HTTP operation.
+The program brings up the Wi-Fi and the underlying network interface and uses it to scan available networks, connects to a network and prints interface and connection details.
 
 For more information about Wi-Fi APIs, please visit the [Mbed OS Wi-Fi](https://os.mbed.com/docs/latest/reference/wi-fi.html) documentation.
 
@@ -38,14 +38,6 @@ For example adding ISM43362 driver `mbed add wifi-ism43362` or X-Nucleo-IDW01M1 
 The ESP8266 driver is already suplied by Mbed OS.
 
 Then pin names need to be configured as instructed in the drivers README file.
-
-#### Connecting the ESP8266 ####
-
-To connect the ESP8266 module to your development board, look at the [ESP8266 Cookbook page](https://developer.mbed.org/users/4180_1/notebook/using-the-esp8266-with-the-mbed-lpc1768/). In general, this means hooking up the ESP8266 TX pin to `D0` and the ESP8266 RX pin to `D1` on your development board.
-
-#### Connecting the X-NUCLEO-IDW0XX1 ####
-
-To connect the [X-NUCLEO-IDW04A1](http://www.st.com/content/st_com/en/products/ecosystems/stm32-open-development-environment/stm32-nucleo-expansion-boards/stm32-ode-connect-hw/x-nucleo-idw04a1.html) or [X-NUCLEO-IDW01M1](https://developer.mbed.org/components/X-NUCLEO-IDW01M1/) expansion board to your NUCLEO development board, plug the expansion board on top of the NUCLEO board using the Arduino or Morpho connector.
 
 ##  Getting started ##
 

--- a/main.cpp
+++ b/main.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "mbed.h"
-#include "TCPSocket.h"
 
 WiFiInterface *wifi;
 
@@ -73,60 +72,8 @@ int scan_demo(WiFiInterface *wifi)
     return count;
 }
 
-void http_demo(NetworkInterface *net)
-{
-    TCPSocket socket;
-    nsapi_error_t response;
-
-    printf("Sending HTTP request to www.arm.com...\n");
-
-    // Open a socket on the network interface, and create a TCP connection to www.arm.com
-    response = socket.open(net);
-    if(0 != response) {
-        printf("socket.open() failed: %d\n", response);
-        return;
-    }
-
-    response = socket.connect("api.ipify.org", 80);
-    if(0 != response) {
-        printf("Error connecting: %d\n", response);
-        socket.close();
-        return;
-    }
-
-    // Send a simple http request
-    char sbuffer[] = "GET / HTTP/1.1\r\nHost: api.ipify.org\r\nConnection: close\r\n\r\n";
-    nsapi_size_t size = strlen(sbuffer);
-
-    // Loop until whole request send
-    while(size) {
-        response = socket.send(sbuffer+response, size);
-        if (response < 0) {
-            printf("Error sending data: %d\n", response);
-            socket.close();
-            return;
-        }
-        size -= response;
-        printf("sent %d [%.*s]\n", response, strstr(sbuffer, "\r\n")-sbuffer, sbuffer);
-    }
-
-    // Receieve a simple http response and print out the response line
-    char rbuffer[64];
-    response = socket.recv(rbuffer, sizeof rbuffer);
-    if (response < 0) {
-        printf("Error receiving data: %d\n", response);
-    } else {
-        printf("recv %d [%.*s]\n", response, strstr(rbuffer, "\r\n")-rbuffer, rbuffer);
-    }
-
-    // Close the socket to return its memory and bring down the network interface
-    socket.close();
-}
-
 int main()
 {
-    int count = 0;
-
     printf("WiFi example\n");
 
 #ifdef MBED_MAJOR_VERSION
@@ -139,9 +86,9 @@ int main()
         return -1;
     }
 
-    count = scan_demo(wifi);
+    int count = scan_demo(wifi);
     if (count == 0) {
-        printf("No WIFI APNs found - can't continue further.\n");
+        printf("No WIFI APs found - can't continue further.\n");
         return -1;
     }
 
@@ -158,8 +105,6 @@ int main()
     printf("Netmask: %s\n", wifi->get_netmask());
     printf("Gateway: %s\n", wifi->get_gateway());
     printf("RSSI: %d\n\n", wifi->get_rssi());
-
-    http_demo(wifi);
 
     wifi->disconnect();
 


### PR DESCRIPTION
Some cleanup of readme and removing the HTTP-part of the wifi example.
The links under Connecting the ESP8266 and Connecting the X-NUCLEO-IDW0XX1 were 404
and X-NUCLEO-IDW01M1 is labeled as deprecated component in developer.mbed.org