### PR TITLE
Add support for WizFi310

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ If the target does not have internal WiFi driver, or Mbed OS does not supply one
 mbed add <driver>
 ```
 
-For example adding ISM43362 driver `mbed add wifi-ism43362` or X-Nucleo-IDW01M1 driver `mbed add wifi-x-nucleo-idw01m1`
+For example adding ISM43362 driver `mbed add wifi-ism43362` or X-Nucleo-IDW01M1 driver `mbed add wifi-x-nucleo-idw01m1` or `mbed add wizfi310-driver`.
+
 The ESP8266 driver is already suplied by Mbed OS.
 
 Then pin names need to be configured as instructed in the drivers README file.

--- a/mbed_app_wizfi310.json
+++ b/mbed_app_wizfi310.json
@@ -1,0 +1,25 @@
+{
+    "config": {
+        "wifi-ssid": {
+            "help": "WiFi SSID",
+            "value": "\"SSID\""
+        },
+        "wifi-password": {
+            "help": "WiFi Password",
+            "value": "\"PASSWORD\""
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "platform.stdio-convert-newlines": true,
+            "wizfi310.debug": false,
+            "wizfi310.provide-default": true, 
+            "wizfi310.tx" : "D1",
+            "wizfi310.rx" : "D0",
+            "wizfi310.cts": "D6",
+            "wizfi310.rts": "D7",
+            "drivers.uart-serial-txbuf-size": 750,
+            "drivers.uart-serial-rxbuf-size": 750
+        }
+    }
+}


### PR DESCRIPTION
Pull in the library, map to the default pins it wants to use via
the Arduino headers.