### PR TITLE
Remove usage of deprecated string-based API

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -101,9 +101,13 @@ int main()
 
     printf("Success\n\n");
     printf("MAC: %s\n", wifi->get_mac_address());
-    printf("IP: %s\n", wifi->get_ip_address());
-    printf("Netmask: %s\n", wifi->get_netmask());
-    printf("Gateway: %s\n", wifi->get_gateway());
+    SocketAddress a;
+    wifi->get_ip_address(&a);
+    printf("IP: %s\n", a.get_ip_address());
+    wifi->get_netmask(&a);
+    printf("Netmask: %s\n", a.get_ip_address());
+    wifi->get_gateway(&a);
+    printf("Gateway: %s\n", a.get_ip_address());
     printf("RSSI: %d\n\n", wifi->get_rssi());
 
     wifi->disconnect();

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#b6e5a0a8afa34dec9dae8963778aebce0c82a54b
+https://github.com/ARMmbed/mbed-os/#64853b354fa188bfe8dbd51e78771213c7ed37f7


### PR DESCRIPTION
String-based APIs were marked deprecated and replaced by `SocketAddress`-based APIs in https://github.com/ARMmbed/mbed-os/pull/11914.
This PR switches the example to the new API and removes the deprecated one.
It will only compile with the PR mentioned above or simply with `mbed-os-5.15` or later (when the new `SocketAddress`-based API is available).