### PR TITLE
Add DISCO_L475VG_IOT01A ISM43362 to default mbed_app.json

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -12,6 +12,12 @@
     "target_overrides": {
         "*": {
             "platform.stdio-convert-newlines": true
+        },
+        "DISCO_L475VG_IOT01A": {
+            "ism43362.provide-default": true
+        },
+        "DISCO_F413ZH": {
+            "ism43362.provide-default": true
         }
     }
 }


### PR DESCRIPTION
ISM43362 is the only connectivity option for DISCO_L475VG_IOT01A.