### PR TITLE
On deployment use mbed-os latest master revision by default

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#64853b354fa188bfe8dbd51e78771213c7ed37f7
+https://github.com/ARMmbed/mbed-os/


### PR DESCRIPTION
Do not rely on release tags any more. This will let us spot issues faster and speed up development.