### PR TITLE
CMake: Add CMake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,93 @@
+# Copyright (c) 2020 Arm Limited. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the License); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an AS IS BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: sh
+os: linux
+dist: xenial
+
+env:
+  global:
+    - PROFILE=develop
+
+cache:
+  pip: true
+  ccache: true
+  # It looks like ccache for arm-none-eabi is not yet supported by Travis.
+  # Therefore manually adding ccache directory to cache
+  directories:
+    - ${HOME}/.ccache
+
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial main'
+        key_url: 'https://apt.kitware.com/keys/kitware-archive-latest.asc'
+      - sourceline: 'deb https://apt.kitware.com/ubuntu/ xenial-rc main'
+    packages:
+      - cmake
+      - ninja-build
+
+matrix:
+  include:
+
+    - &cmake-build-test
+      stage: "CMake"
+      name: "CMake wifi example - develop (DISCO_L475VG_IOT01A)"
+      env: NAME=cmake_test TARGET_NAME=DISCO_L475VG_IOT01A PROFILE=develop CACHE_NAME=develop-DISCO_L475VG_IOT01A
+      language: python
+      python: 3.8
+      install:
+        # Setup ccache
+        - ccache -o compiler_check=content
+        - ccache -M 1G
+        - pushd /usr/lib/ccache
+        - sudo ln -s ../../bin/ccache arm-none-eabi-gcc
+        - sudo ln -s ../../bin/ccache arm-none-eabi-g++
+        - export PATH="/usr/lib/ccache:$PATH"
+        - popd
+        # Install arm-none-eabi-gcc
+        - pushd /home/travis/build && mkdir arm-gcc && cd arm-gcc
+        - curl -L0 "https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2?revision=05382cca-1721-44e1-ae19-1e7c3dc96118&la=en&hash=D7C9D18FCA2DD9F894FD9F3C3DC9228498FA281A" --output gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - tar xf gcc-arm-none-eabi-9-2020-q2-update.tar.bz2
+        - export PATH="$PATH:${PWD}/gcc-arm-none-eabi-9-2020-q2-update/bin"
+        - popd
+        - arm-none-eabi-gcc --version
+        # Hide Travis-preinstalled CMake
+        # The Travis-preinstalled CMake is unfortunately not installed via apt, so we
+        # can't replace it with an apt-supplied version very easily. Additionally, we
+        # can't permit the Travis-preinstalled copy to survive, as the Travis default
+        # path lists the Travis CMake install location ahead of any place where apt
+        # would install CMake to. Instead of apt removing or upgrading to a new CMake
+        # version, we must instead delete the Travis copy of CMake.
+        - sudo rm -rf /usr/local/cmake*
+        - pip install --upgrade mbed-tools
+        - pip install prettytable==0.7.2
+        - pip install future==0.16.0
+        - pip install "Jinja2>=2.10.1,<2.11"
+        - pip install "intelhex>=1.3,<=2.2.1"
+      script:
+        - mbedtools checkout
+        - echo mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - mbedtools build -t GCC_ARM -m ${TARGET_NAME} -b ${PROFILE}
+        - ccache -s
+
+    - <<: *cmake-build-test
+      name: "CMake wifi example - release (DISCO_L475VG_IOT01A)"
+      env: NAME=cmake_test TARGET_NAME=DISCO_L475VG_IOT01A PROFILE=release CACHE_NAME=release-DISCO_L475VG_IOT01A
+
+    - <<: *cmake-build-test
+      name: "CMake wifi example - debug (DISCO_L475VG_IOT01A)"
+      env: NAME=cmake_test TARGET_NAME=DISCO_L475VG_IOT01A PROFILE=debug CACHE_NAME=debug-DISCO_L475VG_IOT01A

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,38 @@
+# Copyright (c) 2020 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_SOURCE_DIR}/.mbedbuild CACHE INTERNAL "")
+set(APP_TARGET mbed-os-example-wifi)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+add_subdirectory(${MBED_PATH})
+
+add_executable(${APP_TARGET})
+
+mbed_configure_app_target(${APP_TARGET})
+
+mbed_set_mbed_target_linker_script(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_sources(${APP_TARGET}
+    PRIVATE
+        main.cpp
+)
+
+target_link_libraries(${APP_TARGET}
+    PRIVATE
+        mbed-os
+        mbed-wifi
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#8ef0a435b2356f8159dea8e427b2935d177309f8
+https://github.com/ARMmbed/mbed-os/#66c05ddbf8da7873108494ec9d243c2d2ca6a283


### PR DESCRIPTION
- Added `CMakeLists.txt` file to wifi example so that it can build via CMake
- Added `.travis.yml` config to pick this example for Travis CI build
- Update mbed-os.lib to latest master to pick CMake changes

@0xc0170 @hugueskamba 

BLOCKED BY: https://github.com/ARMmbed/mbed-tools/issues/116